### PR TITLE
Escape the literal `.` character

### DIFF
--- a/SQLite_Error.txt
+++ b/SQLite_Error.txt
@@ -4,7 +4,7 @@ SQLite\.Exception
 Warning.*?\W(sqlite_|SQLite3::)
 \[SQLITE_ERROR\]
 SQLite error \d+:
-sqlite3.OperationalError:
+sqlite3\.OperationalError:
 SQLite3::SQLException
 org\.sqlite\.JDBC
 Pdo[./_\\]Sqlite


### PR DESCRIPTION
I am pretty sure that `.` character should be escaped so it's not interpreted as the regex any-character.